### PR TITLE
set TTL to 1/2 the lease time for gateway DHCP

### DIFF
--- a/dns/var_lib/db.vlab
+++ b/dns/var_lib/db.vlab
@@ -1,5 +1,5 @@
 $ORIGIN .
-$TTL 1h
+$TTL 5m
 vlab.com             IN SOA  ns.vlab.com. root.vlab.com. (
                                 4          ; Serial
                                 604800     ; Refresh (1 week)

--- a/dns/var_lib/db.vlab.in-addr.arpa
+++ b/dns/var_lib/db.vlab.in-addr.arpa
@@ -1,5 +1,5 @@
 ; Reverse lookup (IP to name)
-$TTL 1h;
+$TTL 5m;
 @    IN    SOA    ns.vlab.com. root.vlab.com. (
                              1  ; Serial
                         604800  ; Refresh (1 week)


### PR DESCRIPTION
A 1 hour TTL for the DDNS records will undoubtedly lead to an issue in the future where, _"I don't know what changed but it just started working again"_ or _"to fix it for this one person, we have to invalidate all the DNS cache."_

With the future plans to have a custom API Gateway service that presents the vLab API as a single opaque thing to clients, caching DNS records for a hour is a bad idea. If a user power cycles their gateway and it acquires a new IP upon boot, the API Gateway would continue to use the old record due to the TTL (assuming it was in the DNS cache of the API Gateway). and the user would be unable to use `vlab connect` until that TTL has expired.

I do not know if a 5 minute window is _the right value_; in fact, I fully expect that future tweaks to the TTL will be needed. However, I do know that a 1 hour TTL will be too big.