### PR TITLE
Bug update key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 	-unset TESTENV
 
 install: clean
-	sudo cp dns/etc/bind/named* /etc/bind/
+	sudo cp dns/etc/bind/* /etc/bind/
 	sudo cp dns/var_lib/db* /var/lib/bind/
 
 test: install

--- a/dns/config_and_run.sh
+++ b/dns/config_and_run.sh
@@ -20,7 +20,8 @@ update_forwarders() {
 update_ddns_key() {
   # Use a user-supplied DDNS key
   if [ ! -z ${VLAB_DDNS_KEY+x} ]; then
-    sed -i -e "s/cmqR1rOrru0sK81Y3u5N784REV2yMdi8tQYjxWL4q35ny8ST7ifvwuPbVmyxPqcjj1VDhJ52ZTJQboOR5IhY/A==/${VLAB_DDNS_KEY}/g" /etc/bind/ddns.key  else
+    local key=$(echo ${VLAB_DDNS_KEY} | sed 's/\//\\\//g')
+    sed -i -e "s/cmqR1rOrru0sK81Y3u5N784REV2yMdi8tQYjxWL4q35ny8ST7ifvwuPbVmyxPqcjj1VDhJ52ZTJQboOR5IhY\/A==/${key}/g" /etc/bind/ddns.key
   else
     echo "**SECURITY WARNING** Using default DDNS key"
   fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,5 +9,6 @@ export VLAB_DNS_FORWARDERS=10.7.190.6,10.7.190.7,
 export VLAB_DNS_REV_ZONE=80.241.10.in-addr.arpa
 export VLAB_IP=10.241.80.12
 export VLAB_FQDN=vlab-dev.igs.corp
+export VLAB_DDNS_KEY=r2a/n4quUpSXzE24p7/KfHSrl0e8SaMcI8jB6bga/7U29vmt9m51oGcL/vTsq9Z93Odx7GiAgcG1vazJbSRq6Q==
 export TESTENV=true
 dns/config_and_run.sh


### PR DESCRIPTION
The DDNS key contains forward slashes, which breaks `sed`.
This PR fixes this issue by escaping all forward slashes in the key.