### PR TITLE
Bug underscores

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,17 @@ environment variables and update the default configs accordingly:
 - ``VLAB_DNS_REV_ZONE`` - The /24 reverse zone name, ex "1.168.192.in-addr.arpa" for the 192.168.1.0/24 subnet
 - ``VLAB_IP`` - The IPv4 Address of the vLab server
 - ``VLAB_FQDN`` - The fully qualified domain name for the vLab server, ex vlab.mycompany.com
+
+
+*********************
+Creating the DDNS_KEY
+*********************
+
+You'll need to have the ``bind9utils`` (``bind9-utils`` for RPM) installed.
+
+Once it's installed, run the following command to generate the key::
+
+  $ sudo dnssec-keygen -a HMAC-SHA512 -b 512 -n USER <your vLab FQDN>
+
+Remember to replace ``<your vLab FQDN>`` with the full qualified domain name
+of your vLab server.

--- a/dns/etc/bind/named.conf.vlab
+++ b/dns/etc/bind/named.conf.vlab
@@ -5,6 +5,7 @@ include "/etc/bind/ddns.key";
 zone "vlab.com" {
   type master;
   notify no;
+  check-names ignore;
   file "/var/lib/bind/db.vlab";
   allow-update { key DDNS_UPDATE; };
 };
@@ -21,6 +22,7 @@ zone "vlab.com" {
 zone "1.168.192.in-addr.arpa" {
   type master;
   notify no;
+  check-names ignore;
   file "/var/lib/bind/db.vlab.in-addr.arpa";
   allow-update { key DDNS_UPDATE; };
 };


### PR DESCRIPTION
Some users end up having an underscore `_` in their AD username. This means that their gateway will get a hostname with an underscore, and as a result, send DDNS updates with an underscore in the hostname.

DNS by default doesn't like this, so BIND9 by default rejects an lookups for a name with an underscore.
This breaks routing between the API Gateway and a user's defaultGateway for those users with an underscore in their name.

This PR fixes this issue by simply updating the BIND9 zone config to not care about having an underscore in the hostname.

http://www.zytrax.com/books/dns/ch7/zone.html